### PR TITLE
fix: Remove Cognitive complexity from test rules

### DIFF
--- a/tests.js
+++ b/tests.js
@@ -8,5 +8,6 @@ module.exports = {
     "no-console": "off",
     "no-unused-expressions": "off",
     "no-unused-vars": ["error", { "argsIgnorePattern": "^_" }],
+    "sonarjs/cognitive-complexity": "off",
   }
 }


### PR DESCRIPTION
Big describe blocks with mocha can be interpreted as cognitive complex (if you are not looking at the last `it` block) triggering sonarjs/cognitive-complexity.

The rule has been disabled in the testing config file.