### PR TITLE
Turn off `unicorn/prevent-abbreviations`

### DIFF
--- a/index.js
+++ b/index.js
@@ -25,6 +25,7 @@ module.exports = {
     "prefer-destructuring": ["error", { "object": true, "array": false }],
     "unicorn/filename-case": "off",
     "unicorn/no-null": "off",
+    "unicorn/prevent-abbreviations": "off",
     "prettier/prettier": ["error", { "singleQuote": true, "printWidth": 150 }]
   },
 };


### PR DESCRIPTION
Was caught out by this rule. It renamed a variable (when I ran `eslint --fix`) without me noticing. I really didn't want that to happen, the variable needed to have a specific name based on the 'CRF' format. 

I was basically doing something along these lines to map values from Athena rows to CRF records:

```
const { uuid: dataSourceRef, first_name: firstName, ...andALoadOfOtherValues } = rowFromAthena;

const crfModel = new CrfModel({ dataSourceRef, firstName, ...etcEtcEtc });
```

Was lucky that it just happened to be one of the non-nullable values on this model, otherwise I may never have noticed.

Not sure it's good to have a rule that will rename your vars, very possibly without you noticing (e.g. if you just run `eslint --fix` over a whole file or have it running on save.)

Thoughts?