### PR TITLE
fix: remove @babel/eslint-parser

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,7 +9,6 @@ module.exports = {
     "es6": true,
     "node": true,
   },
-  "parser": "@babel/eslint-parser",
   "plugins": [
     "flowtype",
     "sonarjs",


### PR DESCRIPTION
Has an history of breaking eslint and we don't need it.