### PR TITLE
Update readme and turn off jsdoc/require-returns-type

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,31 +1,62 @@
 # eslint-config
-Shared Eslint configuration for Comic Relief codebases.
 
-# Configurations
+Shared ESLint configuration for Comic Relief codebases.
 
-The package exposes three eslint configurations:
+## Usage
 
-- `@comicrelief/eslint-config`: Main Eslint configuration, to be used by source files in back-end applications.
-- `@comicrelief/eslint-config/react`: Main Eslint configuration, to be used by source files in front-end applications.
-- `@comicrelief/eslint-config/tests`: Tests Eslint configuration, to be used by test files. It inherits from `@comicrelief/eslint-config` and specifies additional rules required by unit tests and feature tests.
-- `@comicrelief/eslint-config/ts`: Main TypeScript configuration.
+1. Install `eslint` if you haven't already done so.
 
+       yarn add eslint --dev
 
-# Usage
+2. Install this package.
 
-- Install via `yarn add @comicrelief/eslint-config --dev`.
-- Extended the desired configuration in .eslintrc - or wherever eslint config exists:
-````
-{
-  "extends": "@comicrelief/eslint-config"
-}
-````
+       yarn add @comicrelief/eslint-config --dev
 
-# Dependencies
+3. Extend the desired configuration in your project's ESLint config:
+
+   ```yaml
+   # .eslintrc.yml
+   extends:
+     - '@comicrelief/eslint-config'
+   ```
+
+This will give you the default linting configuration, which includes rules from the `flowtype`, `sonarjs` and `unicorn` plugins.
+
+## Mixins
+
+As well as our default ESLint config, various common customisations are available that you can "mix in" to your config:
+
+- `base`: Base configuration that you should extend if you're not using `@comicrelief/eslint-config`. See TypeScript example below.
+- `flowtype`: Adds [Flow typing](https://github.com/gajus/eslint-plugin-flowtype#readme) rules.
+- `jest`: Uses the `jest` environment.
+- `jsdoc`: Adds [JSDoc](https://github.com/gajus/eslint-plugin-jsdoc#readme) rules.
+- `mocha`: Uses the `mocha` environment.
+- `sonarjs`: Adds [SonarJS](https://github.com/SonarSource/eslint-plugin-sonarjs) rules.
+- `unicorn`: Adds [Unicorn](https://github.com/sindresorhus/eslint-plugin-unicorn#readme) rules.
+
+For example, in order for linting to work in tests, you should include the `jest` or `mocha` mixin:
+
+```yaml
+# .eslintrc.yml
+extends:
+  - '@comicrelief/eslint-config'
+  - '@comicrelief/eslint-config/mixins/jest'
+```
+
+When working in TypeScript, many rules that catch common JavaScript errors are no longer needed, and you would not want to use Flow. In this case, rather than use `@comicrelief/eslint-config` you should use `@comicrelief/eslint-config/mixins/base`.
+
+```yaml
+# .eslintrc.yml
+extends:
+  - '@comicrelief/eslint-config/mixins/base'
+  - '@comicrelief/eslint-config/mixins/ts'
+```
+
+## Dependencies
 
 Some of the configurations require additional dependencies. They are not listed as `peerDependencies` in `package.json` as they might not be used in all projects.
 
-## `@comicrelief/eslint-config/ts`
+### `@comicrelief/eslint-config/mixins/ts`
 
 ```bash
 yarn add --dev \
@@ -33,9 +64,10 @@ yarn add --dev \
   @typescript-eslint/parser
 ```
 
-# Development
+## Development
 
 - Clone the repository.
 - Install the dependencies via `yarn install`.
 - Add / edit / remove rules as required.
-- Test on a candidate repo by installing test branch via `@comicrelief/eslint-config@comicrelief/eslint-config#branch_name`.
+- Push a branch to this repo.
+- Test linting on a candidate repo by installing the develpoment branch via `@comicrelief/eslint-config#branch_name`.

--- a/README.md
+++ b/README.md
@@ -71,3 +71,15 @@ yarn add --dev \
 - Add / edit / remove rules as required.
 - Push a branch to this repo.
 - Test linting on a candidate repo by installing the develpoment branch via `@comicrelief/eslint-config#branch_name`.
+
+## Notes
+
+If you're using the [ESLint plugin](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint) for Visual Studio Code and you want to lint TypeScript files, you need to add the following key to your `settings.json`:
+
+```json
+{
+  "eslint.validate": ["typescript"]
+}
+```
+
+The easiest way to edit your `settings.json` is via the Command Palette: ⇧⌘P *Preferences: Open Settings (JSON)*.

--- a/mixins/jsdoc.js
+++ b/mixins/jsdoc.js
@@ -39,6 +39,7 @@ module.exports = {
     // Requiring returns really means
     // requiring types, see above
     "jsdoc/require-returns": "off",
+    "jsdoc/require-returns-type": "off",
 
     // Add custom JSdoc tags
     "jsdoc/check-tag-names": ["error", {


### PR DESCRIPTION
This PR
- updates the readme to explain mixins
- turns off `jsdoc/require-returns-type` because we don't want this in TypeScript

I wonder if we should turn on `jsdoc/require-returns` again, as that seems like something useful. However based on the fact we're not requiring param descriptions (because sometimes they're self-explanatory) I've left it turned off.