### PR TITLE
feat: Implement eslint import order rule

### DIFF
--- a/mixins/base.js
+++ b/mixins/base.js
@@ -12,6 +12,37 @@ module.exports = {
     "import/extensions": "off",
     "import/no-unresolved": "off",
     "import/prefer-default-export": "off",
+    "import/order": ["error", {
+      "alphabetize": {
+        "order": "asc",
+      },
+      "groups": ["builtin", "external", "internal"],
+      "pathGroups": [
+        // Order all @comicrelief packages
+        // just after the external packages
+        {
+          "pattern": "@comicrelief/**",
+          "group": "external",
+          "position": "after",
+        },
+        // Order all @/src/**
+        // just before all local/relative imports
+        {
+          "pattern": "@/src/**",
+          "group": "internal",
+          "position": "before",
+        },
+        // Order all remaining alias
+        // just before all local/relative imports
+        {
+          "pattern": "@/**",
+          "group": "internal",
+          "position": "before",
+        },
+      ],
+      "pathGroupsExcludedImportTypes": ["builtin"],
+      "newlines-between": "always"
+    }],
     "linebreak-style": "off",
     "max-len": "off",
     "no-await-in-loop": "off",

--- a/mixins/base.js
+++ b/mixins/base.js
@@ -52,5 +52,10 @@ module.exports = {
       "varsIgnorePattern": "^_",
     }],
     "prefer-destructuring": "off",
+    // Also order the individual import members
+    // from each file declaration
+    "sort-imports": ["error", {
+      "ignoreDeclarationSort": true,
+    }]
   },
 };


### PR DESCRIPTION
Our imports are not ordered and with complex files this can be quite messy and hard to read and maintain.

The following rule will help us keep things tidy:
https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/order.md

See:
- [ENG-148]

[ENG-148]: https://comicrelief.atlassian.net/browse/ENG-148