### PR TITLE
fix: Turn off `unicorn/prefer-ternary`

### DIFF
--- a/mixins/unicorn.js
+++ b/mixins/unicorn.js
@@ -10,5 +10,6 @@ module.exports = {
     "unicorn/no-null": "off",
     "unicorn/no-array-for-each": "off",
     "unicorn/prevent-abbreviations": "off",
+    "unicorn/prefer-ternary": "off",
   },
 };


### PR DESCRIPTION
Ternary operators almost always make the code harder to understand and
maintain.