### PR TITLE
fix: Disable sonarjs/no-duplicate-string in tests

### DIFF
--- a/mixins/jest.js
+++ b/mixins/jest.js
@@ -7,5 +7,10 @@ module.exports = {
     "func-names": "off",
     "no-console": "off",
     "no-unused-expressions": "off",
+
+    // In tests it may be helpful to just repeat a string
+    // instead of making very different tests dependent
+    // on each other
+    "sonarjs/no-duplicate-string": "off",
   },
 }

--- a/mixins/mocha.js
+++ b/mixins/mocha.js
@@ -7,5 +7,10 @@ module.exports = {
     "func-names": "off",
     "no-console": "off",
     "no-unused-expressions": "off",
+
+    // In tests it may be helpful to just repeat a string
+    // instead of making very different tests dependent
+    // on each other
+    "sonarjs/no-duplicate-string": "off",
   },
 }


### PR DESCRIPTION
In tests it may be helpful to just repeat a string
instead of making very different tests dependent
on each other