### PR TITLE
fix: Turn off rules that crash when linting TypeScript

### DIFF
--- a/mixins/ts.js
+++ b/mixins/ts.js
@@ -14,5 +14,7 @@ module.exports = {
     "@typescript-eslint/semi": "error",
     "no-shadow": "off",
     "@typescript-eslint/no-shadow": "error",
+    "indent": "off",
+    "@typescript-eslint/indent": ["error", 2, { "SwitchCase": 0 }],
   },
 }

--- a/mixins/ts.js
+++ b/mixins/ts.js
@@ -9,12 +9,15 @@ module.exports = {
   ],
   "rules": {
     "@typescript-eslint/no-unused-vars": ["error", { "argsIgnorePattern": "^_" }],
-    // these eslint rules can report incorrect errors in TypeScript files
+    // these rules can report incorrect errors or crash in TypeScript files
     "semi": "off",
-    "@typescript-eslint/semi": "error",
     "no-shadow": "off",
-    "@typescript-eslint/no-shadow": "error",
     "indent": "off",
+    "import/no-webpack-loader-syntax": "off",
+    "import/no-useless-path-segments": "off",
+    // these are the replacement "extension rules" from @typescript-eslint
+    "@typescript-eslint/semi": "error",
+    "@typescript-eslint/no-shadow": "error",
     "@typescript-eslint/indent": ["error", 2, { "SwitchCase": 0 }],
   },
 }


### PR DESCRIPTION
Found a couple more rules that don't work properly with TypeScript. They occasionally cause `eslint` to crash.

`indent` is replaced with `@typescript-eslint/indent`. I had to set the `SwitchCase` option is set explicitly because the default seems to be different to the original `indent` (1 instead of 0).

The two `import` rules don't have a `@typescript-eslint` equivalent, so they would be turned off for TS projects. I tried extending `plugin:import/typescript` in my config as recommended by [eslint-plugin-import's readme](https://github.com/benmosher/eslint-plugin-import#typescript) but this did not fix the crashes from these rules.

Related: #24