### PR TITLE
fix: Add more extension rules for TypeScript

### DIFF
--- a/mixins/ts.js
+++ b/mixins/ts.js
@@ -8,20 +8,22 @@ module.exports = {
     "plugin:@typescript-eslint/recommended"
   ],
   "rules": {
+    // allow unused arguments if prefixed with an underscore
     "@typescript-eslint/no-unused-vars": ["error", { "argsIgnorePattern": "^_" }],
-    // these rules can report incorrect errors or crash in TypeScript files
-    "comma-dangle": "off",
-    "semi": "off",
-    "no-shadow": "off",
-    "no-useless-constructor": "off",
-    "indent": "off",
+    // these rules can crash in TypeScript files
     "import/no-webpack-loader-syntax": "off",
     "import/no-useless-path-segments": "off",
+    // these rules can report incorrect errors in TypeScript files
+    "comma-dangle": "off",
+    "indent": "off",
+    "no-shadow": "off",
+    "no-useless-constructor": "off",
+    "semi": "off",
     // these are the replacement "extension rules" from @typescript-eslint
     "@typescript-eslint/comma-dangle": ["error", "always-multiline"],
-    "@typescript-eslint/semi": "error",
+    "@typescript-eslint/indent": ["error", 2, { "SwitchCase": 0 }],
     "@typescript-eslint/no-shadow": "error",
     "@typescript-eslint/no-useless-constructor": "error",
-    "@typescript-eslint/indent": ["error", 2, { "SwitchCase": 0 }],
+    "@typescript-eslint/semi": "error",
   },
 }

--- a/mixins/ts.js
+++ b/mixins/ts.js
@@ -10,14 +10,18 @@ module.exports = {
   "rules": {
     "@typescript-eslint/no-unused-vars": ["error", { "argsIgnorePattern": "^_" }],
     // these rules can report incorrect errors or crash in TypeScript files
+    "comma-dangle": "off",
     "semi": "off",
     "no-shadow": "off",
+    "no-useless-constructor": "off",
     "indent": "off",
     "import/no-webpack-loader-syntax": "off",
     "import/no-useless-path-segments": "off",
     // these are the replacement "extension rules" from @typescript-eslint
+    "@typescript-eslint/comma-dangle": ["error", "always-multiline"],
     "@typescript-eslint/semi": "error",
     "@typescript-eslint/no-shadow": "error",
+    "@typescript-eslint/no-useless-constructor": "error",
     "@typescript-eslint/indent": ["error", 2, { "SwitchCase": 0 }],
   },
 }


### PR DESCRIPTION
Replaces `comma-dangle` and `no-useless-constructor` rules with their `@typescript-eslint` equivalents.