### PR TITLE
feat: add apidoc mixin

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ As well as our default ESLint config, various common customisations are availabl
 - `mocha`: Uses the `mocha` environment.
 - `sonarjs`: Adds [SonarJS](https://github.com/SonarSource/eslint-plugin-sonarjs) rules.
 - `unicorn`: Adds [Unicorn](https://github.com/sindresorhus/eslint-plugin-unicorn#readme) rules.
+- `apiDoc`: Extends `jsdoc` to include [apiDoc](https://apidocjs.com/) tags.
 
 For example, in order for linting to work in tests, you should include the `jest` or `mocha` mixin:
 

--- a/mixins/apiDoc.js
+++ b/mixins/apiDoc.js
@@ -31,12 +31,5 @@ module.exports = {
         ],
       },
     ],
-    // Allows for spaces of JSDoc and other comment blocks. This is disabled by the base config, but helps for formatting.
-    "no-trailing-spaces": [
-      "error",
-      {
-        ignoreComments: true,
-      },
-    ],
   },
 };

--- a/mixins/apiDoc.js
+++ b/mixins/apiDoc.js
@@ -28,7 +28,6 @@ module.exports = {
           "apiSuccessExample",
           "apiUse",
           "apiVersion",
-          "mermaid",
         ],
       },
     ],

--- a/mixins/apiDoc.js
+++ b/mixins/apiDoc.js
@@ -1,0 +1,43 @@
+module.exports = {
+  rules: {
+    // Add custom JSdoc tags required for apiDoc.
+    "jsdoc/check-tag-names": [
+      "error",
+      {
+        definedTags: [
+          "api",
+          "apiBody",
+          "apiDefine",
+          "apiDeprecated",
+          "apiDescription",
+          "apiError",
+          "apiErrorExample",
+          "apiExample",
+          "apiGroup",
+          "apiHeader",
+          "apiHeaderExample",
+          "apiIgnore",
+          "apiName",
+          "apiParam",
+          "apiParamExample",
+          "apiPermission",
+          "apiPrivate",
+          "apiQuery",
+          "apiSampleRequest",
+          "apiSuccess",
+          "apiSuccessExample",
+          "apiUse",
+          "apiVersion",
+          "mermaid",
+        ],
+      },
+    ],
+    // Allows for spaces of JSDoc and other comment blocks. This is disabled by the base config, but helps for formatting.
+    "no-trailing-spaces": [
+      "error",
+      {
+        ignoreComments: true,
+      },
+    ],
+  },
+};


### PR DESCRIPTION
## Why is this required?
Improvements to mailer docs in the attached ticket, hightlighted the fact that [apiDoc](https://apidocjs.com/) syntax causes some conflicts with `eslint-plugin-jsdoc`.

## What is it doing?
Adds a new apiDoc mixin to be included in eslint configs when required.

## Jira ticket:
Jira: [ENG-1256]

[ENG-1256]: https://comicrelief.atlassian.net/browse/ENG-1256?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ