### PR TITLE
chore: manually bump versions of some plugins to fix breaking changes with E…

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "author": "Comic Relief",
   "license": "MIT",
   "peerDependencies": {
-    "eslint": ">=7.6.0"
+    "eslint": ">=8.17.0"
   },
   "devDependencies": {
     "semantic-release": "^17.1.1"
@@ -17,13 +17,13 @@
     "@typescript-eslint/parser": "^4.7.0",
     "eslint-config-airbnb": "^18.2.1",
     "eslint-config-airbnb-base": "^14.2.1",
-    "eslint-plugin-flowtype": ">=5.2.0",
+    "eslint-plugin-flowtype": ">=8.0.3",
     "eslint-plugin-import": ">=2.3.0",
-    "eslint-plugin-jsdoc": "^30.7.7",
-    "eslint-plugin-jsx-a11y": ">=6.2.3",
-    "eslint-plugin-react": ">=7.20.5",
-    "eslint-plugin-sonarjs": ">=0.5.0",
-    "eslint-plugin-unicorn": ">=21.0.0",
+    "eslint-plugin-jsdoc": "^39.3.2",
+    "eslint-plugin-jsx-a11y": ">=6.5.1",
+    "eslint-plugin-react": ">=7.30.0",
+    "eslint-plugin-sonarjs": ">=0.13.0",
+    "eslint-plugin-unicorn": ">=42.0.0",
     "typescript": "^4.0.5"
   },
   "publishConfig": {


### PR DESCRIPTION
## Why is this required?

New versions of `eslint-plugin-flowtype` and `eslint-plugin-unicorn` no longer appear to play nice with ESLint v7.x.x, and as we use >= versions, this was breaking linting when a version mismatch occured.

## What is it doing?

Upadted ESLint peer dep to latest version and updated plugins to versions which support ESLint 8.