### PR TITLE
fix: Allow lines between apiDoc tags

### DIFF
--- a/mixins/apiDoc.js
+++ b/mixins/apiDoc.js
@@ -31,5 +31,7 @@ module.exports = {
         ],
       },
     ],
+    // Allow blank lines between tags
+    "jsdoc/tag-lines": "off",
   },
 };

--- a/tests/apidoc/index.js
+++ b/tests/apidoc/index.js
@@ -5,10 +5,10 @@
  * @apiName GetUser
  * @apiGroup User
  *
- * @apiParam {Number} id Users unique ID.
+ * @apiParam {number} id Users unique ID.
  *
- * @apiSuccess {String} firstname Firstname of the User.
- * @apiSuccess {String} lastname  Lastname of the User.
+ * @apiSuccess {string} firstname Firstname of the User.
+ * @apiSuccess {string} lastname  Lastname of the User.
  *
  * @apiSuccessExample Success-Response:
  *     HTTP/1.1 200 OK


### PR DESCRIPTION
As discussed in #36. I've also updated the example JSDoc to fix the remaining warnings.