### PR TITLE
ci: Use our org-wide npm token for publishing

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -44,7 +44,7 @@ jobs:
           yarn semantic-release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NPM_TOKEN: ${{ secrets.NPM_PUBLISHING_TOKEN }}
 
       - name: Setup for Github Package Registry
         uses: actions/setup-node@v1


### PR DESCRIPTION
Currently seems to be using one of my personal tokens. This change will switch to publishing under our Engineering Ops account instead.